### PR TITLE
Sitecat request test

### DIFF
--- a/lib/aokay/requests/base_request.rb
+++ b/lib/aokay/requests/base_request.rb
@@ -9,6 +9,12 @@ module Aokay
       @parsed_url = Addressable::URI.parse req.url
     end
 
+    # We say that requests are equal if their parameters are equal.
+    # This is open to change.
+    def ==(other)
+      self.params == other.params
+    end
+
     class << self
       def network_traffic
         Capybara.page.driver.network_traffic
@@ -40,6 +46,17 @@ module Aokay
     def successful?
       codes = self.req.response_parts.map{|resp| resp.status}.uniq
       codes.map!{|code| code == 200}.reduce
+    end
+
+    # Here's why we need this.
+    #
+    #  When we ask for Capybara.page.driver.network_traffic, we can
+    #  ask for the traffic before the response for the last request
+    #  has been "received".  The first time you make the request, the
+    #  object you get back won't have @response_parts or @error, but
+    #  the *second* time, it will.
+    def responded?
+      self.req.response_parts.any? || self.req.error
     end
 
     def host

--- a/lib/aokay/requests/base_request.rb
+++ b/lib/aokay/requests/base_request.rb
@@ -43,7 +43,7 @@ module Aokay
     end
 
     def host
-      @parsed_url.host 
+      @parsed_url.host
     end
 
     def params
@@ -59,8 +59,9 @@ module Aokay
     end
 
     def tracked key
-      key = key.tr(' ', '_').to_sym if key.class == String
-      @parsed_url.query_values[field_ref[key]]
+      key = key.tr(' ', '_').to_sym if key.is_a? String
+      field = field_ref[key]
+      params && params[field]
     end
 
   end

--- a/lib/aokay/requests/base_request.rb
+++ b/lib/aokay/requests/base_request.rb
@@ -12,8 +12,14 @@ module Aokay
     # We say that requests are equal if their parameters are equal.
     # This is open to change.
     def ==(other)
-      self.params == other.params
+      self.class == other.class && self.params == other.params
     end
+    alias_method :eql?, :==
+
+    def hash
+      self.class.object_id ^ self.params.hash
+    end
+
 
     class << self
       def network_traffic

--- a/lib/aokay/requests/sitecat_request.rb
+++ b/lib/aokay/requests/sitecat_request.rb
@@ -1,8 +1,8 @@
 module Aokay
   class SitecatRequest < BaseRequest
 
-    def matches? 
-      !!(host =~ /#{escaped_sitecat_host}/) 
+    def matches?
+      !!(host =~ /#{escaped_sitecat_host}/)
     end
 
     def escaped_sitecat_host
@@ -34,17 +34,21 @@ module Aokay
     end
 
     def tracked key, type=:eVar
+      unless field_ref
+        raise "Aokay Sitecat field refs not set, please set these in your configuration"
+      end
+
       begin
-        if field_ref[key.to_sym].is_a? Hash
-          @parsed_url.query_values[field_ref[key.to_sym][type]]
+        key_sym = key.to_sym
+        field = field_ref[key.to_sym]
+        if field.is_a? Hash
+          @parsed_url.query_values[field[type]]
         else
           super key
         end
       rescue
-        raise "Aokay Sitecat field refs not set, please set these in your configuration"
+        raise "Aokay Sitecat field #{key.inspect} not set, please set this in your configuration"
       end
     end
-
-    private #----------------------------------------------
   end
 end

--- a/spec/sitecat_request_spec.rb
+++ b/spec/sitecat_request_spec.rb
@@ -20,4 +20,18 @@ describe Aokay::SitecatRequest, "#find_requests", type: :feature do
     result = Aokay::SitecatRequest.last
     expect(result[:pageName]).to eq "myPageName"
   end
+
+  it "defines equality" do
+    visit '/'
+    url = "http://metrics.sky.com"
+    make_ajax_req url
+
+    loop until Aokay::SitecatRequest.last.responded?
+
+    first_instance = Aokay::SitecatRequest.last
+    second_instance = Aokay::SitecatRequest.last
+
+    expect(first_instance).to eq second_instance
+  end
+
 end

--- a/spec/sitecat_request_spec.rb
+++ b/spec/sitecat_request_spec.rb
@@ -34,4 +34,14 @@ describe Aokay::SitecatRequest, "#find_requests", type: :feature do
     expect(first_instance).to eq second_instance
   end
 
+  it "works as a hash key" do
+    visit '/'
+    url = "http://metrics.sky.com"
+    make_ajax_req url
+
+    first_instance = Aokay::SitecatRequest.last
+    second_instance = Aokay::SitecatRequest.last
+
+    expect({first_instance => 1, second_instance => 1}.size).to eq 1
+  end
 end

--- a/spec/sitecat_request_spec.rb
+++ b/spec/sitecat_request_spec.rb
@@ -1,4 +1,6 @@
-describe Aokay::SitecatRequest, "#find_requests", type: :feature do 
+require 'spec_helper'
+
+describe Aokay::SitecatRequest, "#find_requests", type: :feature do
 
   it "should return an array of sitecat requests" do
     visit '/'
@@ -9,9 +11,13 @@ describe Aokay::SitecatRequest, "#find_requests", type: :feature do
     expect(result.last).to be_a_kind_of(Aokay::SitecatRequest)
   end
 
-  xit "should allow lookup of variables with friendly names" do
+  it "should allow lookup of variables with friendly names" do
+    page_name_key = RSpec.configuration.aokay_sitecat_refs[:pageName]
+    url = "http://metrics.sky.com?#{page_name_key}=myPageName"
+
     visit '/'
-    make_ajax_req "http://tracking.example.com"
-    result = Aokay::SitecatRequest.all
+    make_ajax_req url
+    result = Aokay::SitecatRequest.last
+    expect(result[:pageName]).to eq "myPageName"
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,7 +21,7 @@ RSpec.configure do |config|
       :contentType => {prop: 'contentType',eVar: 'contentType20'},
       :url => {prop: 'url',eVar: 'url9'}
     }
-    config.aokay_sitecat_url = 'metrics.sky.com'
+  config.aokay_sitecat_url = 'metrics.sky.com'
 end
 
 def make_ajax_req url


### PR DESCRIPTION
This PR fills in a previously skipped test, and adds methods to allow `Aokay::SitecatRequest` instances to be used as hash keys, comparing on the parameters sent.
