### PR TITLE
Remove wrong dep

### DIFF
--- a/aokay.gemspec
+++ b/aokay.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |spec|
 
 
   spec.add_dependency "rspec", "~> 3"
-  spec.add_dependency "wrong"
 
   spec.add_development_dependency "bundler", "~> 1.5"
   spec.add_development_dependency "pry"

--- a/lib/aokay.rb
+++ b/lib/aokay.rb
@@ -3,6 +3,5 @@ require 'aokay/requests/base_request'
 require 'aokay/requests/google_analytics_request'
 require 'aokay/requests/sitecat_request'
 require 'aokay/helpers'
-require 'wrong'
 
 require "addressable/uri"


### PR DESCRIPTION
`wrong` is not used in this lib and is causing crazy dependencies trees in contactus.

Also last update to it was `on Nov 23, 2014`